### PR TITLE
Added left and right margins to OpenLinkConfirm

### DIFF
--- a/src/components/popouts/OpenLinkConfirm.vue
+++ b/src/components/popouts/OpenLinkConfirm.vue
@@ -171,6 +171,8 @@ export default defineComponent({
   color: var(--link-color);
   margin-top: 5px;
   margin-bottom: 5px;
+  margin-right: 10px;
+  margin-left: 10px;
   overflow: auto;
   max-height: 200px;
 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/48490268/137601799-c589f7c1-791f-4c4e-b5a2-5b5327469898.png)

After:

![image](https://user-images.githubusercontent.com/48490268/137601788-49d54004-5536-4067-ac08-ea9643610b16.png)
